### PR TITLE
Added equivalence checking after shuffling

### DIFF
--- a/src/Verismith/OptParser.hs
+++ b/src/Verismith/OptParser.hs
@@ -89,7 +89,10 @@ data Opts
       shuffleOptTop :: !Text,
       shuffleOptOutput :: !(Maybe FilePath),
       shuffleOptShuffleLines :: !Bool,
-      shuffleOptRenameVars :: !Bool
+      shuffleOptRenameVars :: !Bool,
+      shuffleOptEquiv :: !Bool,
+      shuffleOptEquivFolder :: !FilePath,
+      shuffleOptChecker :: !(Maybe Text)
     }
   | Equiv
     { equivOutput :: !FilePath,
@@ -345,6 +348,23 @@ shuffleOpts =
             Opt.long "no-rename-vars"
               <> Opt.help
                 "Rename the variables in a Verilog file." )
+    <*> ( Opt.switch $
+            Opt.long "noequiv"
+              <> Opt.help
+                "Do not check equivalence between input and output (currently only verismith generated Verilog is likely to pass this equivalence check)." )
+    <*> ( Opt.strOption $
+            Opt.long "equiv-output"
+              <> Opt.short 'e'
+              <> Opt.metavar "FOLDER"
+              <> Opt.help "Output folder to write the equivalence checking files in."
+              <> Opt.showDefault
+              <> Opt.value "equiv"
+        )
+    <*> ( Opt.optional . textOption $
+            Opt.long "checker"
+              <> Opt.metavar "CHECKER"
+              <> Opt.help "Define the checker to use."
+        )
 
 reduceOpts :: Parser Opts
 reduceOpts =

--- a/src/Verismith/Shuffle.hs
+++ b/src/Verismith/Shuffle.hs
@@ -112,6 +112,12 @@ shuffleLinesIO = Hog.sample . shuffleLines
 renameVariablesIO :: (SourceInfo a) -> IO (SourceInfo a)
 renameVariablesIO =  Hog.sample . renameVariables
 
+runShuffle :: Bool -> Bool -> SourceInfo a -> IO (SourceInfo a)
+runShuffle nshuf nren sv = do
+  sv' <- fopt nren renameVariablesIO sv
+  fopt nshuf shuffleLinesIO sv'
+  where fopt o f = if o then return else f
+
 m' :: SourceInfo ()
 m' = SourceInfo "m" [verilog|
 module fir_kernel_4tap_arch_1 #(


### PR DESCRIPTION
At the moment the whole thing is brittle, only verismith generated outputs will pass shuffling equivalence check.