### PR TITLE
Add flake.nix support.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716542837,
+        "narHash": "sha256-lJHzC1gvdVVgi0UyYmk/iLoGLsRnYVc4briX3SKStn4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c9102f72fb0153c771da2d26926e89948f7d3f84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "A flake for the Haskell Verismith project";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... } @ inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in {
+        packages = {
+          verismith = pkgs.haskellPackages.callCabal2nix "verismith" (./.) {};
+        };
+        defaultPackage = self.packages.${system}.verismith;
+      }
+    );
+}

--- a/test/Parser.hs
+++ b/test/Parser.hs
@@ -27,6 +27,7 @@ import Verismith
 import Verismith.Verilog.Lex
 import Verismith.Verilog.Parser
 import Verismith.Verilog.Preprocess (uncomment)
+import Verismith.Utils
 
 smallConfig :: Config
 smallConfig = defaultConfig & configProperty . propSize .~ 5

--- a/verismith.cabal
+++ b/verismith.cabal
@@ -161,7 +161,7 @@ test-suite test
                , lens >=4.16.1 && <5.3
                , parsec >= 3.1 && < 3.2
                , tasty >=1.0.1.1 && <1.5
-               , tasty-hedgehog >=1.0 && <1.2
+               , tasty-hedgehog >=1.0 && <1.5
                , tasty-hunit >=0.10 && <0.11
                , text >=1.2 && <2.1
   default-extensions: OverloadedStrings


### PR DESCRIPTION
When trying to build with flake, found two issues, which have been solved:
- Required tasty-hedgedog version not found
- showT not found in test/Parser.hs

Tested locally and it builds verismith without issues.