### PR TITLE
Add explicit imports to fix build issues

### DIFF
--- a/src/Verismith/Verilog2005/Generator.hs
+++ b/src/Verismith/Verilog2005/Generator.hs
@@ -19,7 +19,7 @@ where
 import Control.Applicative (liftA2, liftA3)
 import Data.Functor.Compose
 import Control.Lens hiding ((<.>))
-import Control.Monad (join)
+import Control.Monad (join, replicateM)
 import Control.Monad.Reader
 import Control.Monad.State.Lazy
 import qualified Data.ByteString as B

--- a/src/Verismith/Verilog2005/Randomness.hs
+++ b/src/Verismith/Verilog2005/Randomness.hs
@@ -33,7 +33,7 @@ module Verismith.Verilog2005.Randomness
 where
 
 import Control.Applicative (liftA2)
-import Control.Monad (join)
+import Control.Monad (join, replicateM)
 import Control.Monad.Reader
 import qualified Data.ByteString as B
 import Data.List

--- a/test/Parser.hs
+++ b/test/Parser.hs
@@ -24,6 +24,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.Hedgehog
 import Text.Parsec
 import Verismith
+import Verismith.Utils (showT)
 import Verismith.Verilog.Lex
 import Verismith.Verilog.Parser
 import Verismith.Verilog.Preprocess (uncomment)


### PR DESCRIPTION
Hi there!

First, I'm currently absolutely not familiar with build and import systems for Haskell.
When building Verismith with `nix-build` like said in the documentation, I encountered issues that said that replicateM and showT were out of scope. These minor fixes seem to solve it.

Thanks!
Flavien